### PR TITLE
let mogi manager debug votes if they voted yet

### DIFF
--- a/cogs/debugging.py
+++ b/cogs/debugging.py
@@ -28,8 +28,11 @@ class debugging(commands.Cog):
         await ctx.respond(f"Current Mogi: \n{ctx.mogi}")
 
     @debug.command(name="votes", description="check the votes for the current mogi")
-    @is_moderator()
+    @is_mogi_manager()
     async def votes(self, ctx: MogiApplicationContext):
+        if ctx.interaction.user.id not in ctx.mogi.voters:
+            return await ctx.respond("You have not voted yet", ephemeral=True)
+
         votes_str = "\n".join(
             [
                 f"{format}: {amount}"


### PR DESCRIPTION
this would modify `/debug votes` to be usable by mogi managers and limit the command to only be usable if the user has voted yet