### PR TITLE
rewrite `data_manager`

### DIFF
--- a/cogs/debug.py
+++ b/cogs/debug.py
@@ -9,7 +9,9 @@ from discord.ext import commands
 
 from models import MogiApplicationContext, Room
 
-from utils.data import mogi_manager, state_manager, data_manager, archive_type
+from utils.database.types import archive_type
+
+from utils.data import mogi_manager, state_manager, data_manager
 from utils.command_helpers import confirmation
 from utils.decorators import (
     is_admin,
@@ -65,10 +67,10 @@ class debug(commands.Cog):
             backup_folder, f"backup_{datetime.now().strftime(date_format)}.json"
         )
         backup_data = {
-            "players": data_manager.get_all_player_entries(
-                archive=archive_type.INCLUDE, with_id=False
+            "players": data_manager.Players.get_profiles(
+                archive=archive_type.INCLUDE, with_id=False, as_json=True
             ),
-            "mogis": data_manager.get_all_mogi_entries(with_id=False),
+            "mogis": data_manager.Mogis.get_all_mogis(with_id=False, as_json=True),
         }
 
         with open(backup_filename, "w") as backup_file:

--- a/cogs/mogi/events.py
+++ b/cogs/mogi/events.py
@@ -28,7 +28,9 @@ class events(commands.Cog):
 
         await ctx.defer()
 
-        data_manager.bulk_add_mmr([player.name for player in ctx.mogi.players], amount)
+        data_manager.Mogis.bulk_add_mmr(
+            [player.name for player in ctx.mogi.players], amount
+        )
 
         await ctx.respond(f"{amount} MMR given to all players")
 

--- a/cogs/mogi/manage/sub.py
+++ b/cogs/mogi/manage/sub.py
@@ -50,8 +50,8 @@ class sub(commands.Cog):
             required=False,
         ),
     ):
-        player_profile = data_manager.find_player(player_name)
-        replacement_profile = data_manager.find_player(replacement_name)
+        player_profile = data_manager.Players.find(player_name)
+        replacement_profile = data_manager.Players.find(replacement_name)
 
         if not player_profile:
             return await ctx.respond("Player profile not found", ephemeral=True)

--- a/cogs/mogi/manage/swap.py
+++ b/cogs/mogi/manage/swap.py
@@ -30,9 +30,11 @@ class swap(commands.Cog):
         player2: str = Option(str, name="player2", description="second player"),
     ):
         return await ctx.respond("This command is out of order.")
-        first_player: PlayerProfile | str = data_manager.find_player(player1) or player1
+        first_player: PlayerProfile | str = (
+            data_manager.Players.find(player1) or player1
+        )
         second_player: PlayerProfile | str = (
-            data_manager.find_player(player2) or player2
+            data_manager.Players.find(player2) or player2
         )
         for player in [first_player, second_player]:
             if isinstance(player, str):

--- a/cogs/mogi/mogi.py
+++ b/cogs/mogi/mogi.py
@@ -37,7 +37,7 @@ class mogi(commands.Cog):
     async def close(self, ctx: MogiApplicationContext):
         await ctx.interaction.response.defer()
 
-        player: PlayerProfile | None = data_manager.find_player(ctx.user.id)
+        player: PlayerProfile | None = data_manager.Players.find(ctx.user.id)
         if not player:
             return await ctx.respond("Couldn't find your Profile")
         if (

--- a/cogs/mogi/team_tags.py
+++ b/cogs/mogi/team_tags.py
@@ -52,7 +52,7 @@ class team_tags(commands.Cog):
                     "You cannot include another player's name in your tag."
                 )
 
-        player: PlayerProfile = data_manager.find_player(ctx.interaction.user.id)
+        player: PlayerProfile = data_manager.Players.find(ctx.interaction.user.id)
 
         team_i = [i for i, subarray in enumerate(ctx.mogi.teams) if player in subarray][
             0

--- a/cogs/profiles/disconnects.py
+++ b/cogs/profiles/disconnects.py
@@ -5,7 +5,8 @@ from models import MogiApplicationContext
 
 from utils.decorators import is_mogi_manager, is_moderator, other_player
 
-from utils.data import data_manager, archive_type
+from utils.database.types import archive_type
+from utils.data import data_manager
 
 
 class disconnects(commands.Cog):
@@ -66,7 +67,9 @@ class disconnects(commands.Cog):
     )
     async def disconnects_list(self, ctx: MogiApplicationContext):
         # Get all players and filter out those without disconnects field
-        all_players = data_manager.get_all_player_entries(archive=archive_type.INCLUDE)
+        all_players = data_manager.Players.get_profiles(
+            archive=archive_type.INCLUDE, as_json=True
+        )
         players_with_dcs = [
             p
             for p in all_players

--- a/cogs/profiles/edit.py
+++ b/cogs/profiles/edit.py
@@ -3,7 +3,6 @@ from discord.ext import commands
 
 from models import MogiApplicationContext, PlayerProfile
 
-from utils.data._database import db_players
 from utils.data import data_manager, mogi_manager
 
 from utils.command_helpers import get_guild_member
@@ -108,7 +107,7 @@ class edit(commands.Cog):
         if not player:
             await ctx.respond("Couldn't find that player")
 
-        db_players.delete_one({"_id": player._id})
+        data_manager.Players.delete(player)
 
         if try_remove_roles:
             discord_member: Member | None = await get_guild_member(

--- a/cogs/profiles/edit.py
+++ b/cogs/profiles/edit.py
@@ -68,7 +68,7 @@ class edit(commands.Cog):
         ),
         new_name: str = Option(str, name="newname", description="new username"),
     ):
-        player: PlayerProfile = data_manager.find_player(searched_player)
+        player: PlayerProfile = data_manager.Players.find(searched_player)
 
         if not player:
             await ctx.respond("Couldn't find that player")
@@ -103,7 +103,7 @@ class edit(commands.Cog):
             bool, name="try_remove_roles", description="Try removing Lounge roles"
         ),
     ):
-        player: PlayerProfile = data_manager.find_player(searched_player)
+        player: PlayerProfile = data_manager.Players.find(searched_player)
 
         if not player:
             await ctx.respond("Couldn't find that player")

--- a/cogs/profiles/penalties.py
+++ b/cogs/profiles/penalties.py
@@ -17,7 +17,7 @@ class penalties(commands.Cog):
     )
     async def bank(self, ctx: MogiApplicationContext):
 
-        player: PlayerProfile = data_manager.find_player("mrboost")
+        player: PlayerProfile = data_manager.Players.find("mrboost")
 
         if not player:
             return await ctx.respond("Couldn't find that player")
@@ -45,8 +45,8 @@ class penalties(commands.Cog):
         player=Option(str, "Player to collect penalties from"),
         mmr=Option(int, "MMR to collect"),
     ):
-        player_profile: PlayerProfile = data_manager.find_player(player)
-        penalty_holder: PlayerProfile = data_manager.find_player(self.bot.user.id)
+        player_profile: PlayerProfile = data_manager.Players.find(player)
+        penalty_holder: PlayerProfile = data_manager.Players.find(self.bot.user.id)
 
         if not player_profile:
             return await ctx.respond("Couldn't find that player")

--- a/cogs/profiles/player.py
+++ b/cogs/profiles/player.py
@@ -3,7 +3,8 @@ from discord.ui import View, Button
 from discord.ext import commands
 
 from models import MogiApplicationContext, PlayerProfile, Rank
-from utils.data import data_manager, archive_type
+from utils.database.types import archive_type
+from utils.data import data_manager
 
 from datetime import datetime
 from bson.int64 import Int64
@@ -24,7 +25,7 @@ class player(commands.Cog):
             required=False,
         ),
     ):
-        player: PlayerProfile = data_manager.find_player(
+        player: PlayerProfile = data_manager.Players.find(
             searched_name or Int64(ctx.author.id), archive=archive_type.INCLUDE
         )
 

--- a/cogs/profiles/register.py
+++ b/cogs/profiles/register.py
@@ -14,7 +14,6 @@ from discord.utils import get
 from discord.ext import commands
 
 from models import MogiApplicationContext
-from utils.data._database import db_players, client
 from utils.command_helpers import create_embed, REGIONS, VerificationView
 from utils.maths.readable_timediff import readable_timedelta
 
@@ -22,6 +21,7 @@ from logger import setup_logger
 
 from bson.int64 import Int64
 from config import LOG_CHANNEL_ID
+from utils.data.data_manager import data_manager
 
 lounge_logger = setup_logger(__name__, "lounge.log", "a", console=False)
 
@@ -53,9 +53,7 @@ class register(commands.Cog):
                 "You're not in the right channel for this command.", ephemeral=True
             )
 
-        existingPlayer = (
-            db_players.find_one({"discord_id": Int64(ctx.author.id)}) or None
-        )
+        existingPlayer = data_manager.Players.find(ctx.author.id) or None
         if existingPlayer:
             return await ctx.respond(
                 "You are already registered for Lounge.\nIf your Profile is archived or you're missing the Lounge roles due to rejoining the server, contact a moderator.",
@@ -63,7 +61,7 @@ class register(commands.Cog):
             )
 
         ## more or less temporary code for people who come back after the season reset
-        existingPlayer = (
+        """ existingPlayer = (
             client.get_database("season-3-lounge")
             .get_collection("players")
             .find_one({"discord_id": Int64(ctx.author.id)})
@@ -72,7 +70,7 @@ class register(commands.Cog):
             return await ctx.respond(
                 "You played in Season 3 but left the server since. Please contact an Admin to get your Profile migrated",
                 ephemeral=True,
-            )
+            ) """
 
         # username shenanigans
         def normalize_fancy_unicode(text: str) -> str:
@@ -100,7 +98,7 @@ class register(commands.Cog):
         if username == "":
             username = ctx.interaction.user.name.lower()
 
-        if db_players.find_one({"name": username}):
+        if data_manager.Players.find(username):
             return await ctx.respond(
                 "This username is already taken. Try changing your server display name or ask a moderator for help.",
                 ephemeral=True,
@@ -137,15 +135,8 @@ class register(commands.Cog):
 
         # Verification passed - proceed with registration
         try:
-            db_players.insert_one(
-                {
-                    "name": username,
-                    "discord_id": Int64(member.id),
-                    "mmr": 2000,
-                    "history": [],
-                    "joined": round(time.time()),
-                    "formats": {str(i): 0 for i in range(7)},
-                },
+            data_manager.Players.create_new_player(
+                username=username, discord_id=member.id
             )
         except Exception as e:
             return await ctx.respond(

--- a/cogs/profiles/register.py
+++ b/cogs/profiles/register.py
@@ -14,7 +14,7 @@ from discord.utils import get
 from discord.ext import commands
 
 from models import MogiApplicationContext
-from utils.data._database import db_players, db_archived, client
+from utils.data._database import db_players, client
 from utils.command_helpers import create_embed, REGIONS, VerificationView
 from utils.maths.readable_timediff import readable_timedelta
 
@@ -54,9 +54,7 @@ class register(commands.Cog):
             )
 
         existingPlayer = (
-            db_players.find_one({"discord_id": Int64(ctx.author.id)})
-            or db_archived.find_one({"discord_id": Int64(ctx.author.id)})
-            or None
+            db_players.find_one({"discord_id": Int64(ctx.author.id)}) or None
         )
         if existingPlayer:
             return await ctx.respond(

--- a/cogs/profiles/suspend.py
+++ b/cogs/profiles/suspend.py
@@ -3,7 +3,8 @@ from discord.ext import commands
 
 from models import MogiApplicationContext, PlayerProfile
 
-from utils.data import data_manager, archive_type
+from utils.database.types import archive_type
+from utils.data import data_manager
 from utils.decorators import is_moderator
 
 
@@ -24,7 +25,7 @@ class suspend(commands.Cog):
             str, name="player", description="username | @ mention | discord_id"
         ),
     ):
-        player: PlayerProfile = data_manager.find_player(
+        player: PlayerProfile = data_manager.Player.find(
             searched_player, archive=archive_type.INCLUDE
         )
 
@@ -44,7 +45,7 @@ class suspend(commands.Cog):
             str, name="player", description="username | @ mention | discord_id"
         ),
     ):
-        player: PlayerProfile = data_manager.find_player(
+        player: PlayerProfile = data_manager.Players.find(
             searched_player, archive=archive_type.INCLUDE
         )
 

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -1,7 +1,7 @@
 from discord import slash_command, Color
 from discord.ext import commands
 
-from utils.data._database import db_mogis
+from utils.data import data_manager
 from models import MogiApplicationContext, MogiHistoryData
 from utils.command_helpers import create_embed
 from datetime import datetime
@@ -16,7 +16,7 @@ class stats(commands.Cog):
 
     @slash_command(name="stats", description="Show Lounge stats for the current season")
     async def stats(self, ctx: MogiApplicationContext):
-        all_mogis = [MogiHistoryData.from_dict(mogi) for mogi in list(db_mogis.find())]
+        all_mogis: list[MogiHistoryData] = data_manager.Mogis.get_all_mogis()
 
         durations = [
             datetime.fromtimestamp(mogi.finished_at)

--- a/cogs/table_reader/table_read.py
+++ b/cogs/table_reader/table_read.py
@@ -251,13 +251,13 @@ class table_read(commands.Cog):
                 )
 
         searched_player = (
-            data_manager.find_player(query=to_player) if to_player else None
+            data_manager.Players.find(query=to_player) if to_player else None
         )
         if to_player and not searched_player:
             return await ctx.respond("Couldn't find that player")
 
-        data_manager.set_player_alias(
-            searched_player.name if searched_player else ctx.player.name, name
+        data_manager.Aliases.set_player_alias(
+            searched_player if searched_player else ctx.player, name
         )
         return await ctx.respond(
             f"{searched_player.name if searched_player else ctx.player.name} -> `{name}`"
@@ -268,7 +268,7 @@ class table_read(commands.Cog):
         await ctx.respond(
             "\n".join(
                 f"{key}: {value}"
-                for key, value in (data_manager.get_all_aliases()).items()
+                for key, value in (data_manager.Aliases.get_all_aliases()).items()
                 if key is not "_id"
             )
         )

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -11,7 +11,8 @@ from discord import Activity, ActivityType, Status, AllowedMentions
 from discord.ext import commands, tasks
 from discord.utils import get
 
-from utils.data import data_manager, archive_type, state_manager, mogi_manager
+from utils.database.types import archive_type
+from utils.data import data_manager, state_manager, mogi_manager
 
 from utils.command_helpers import fetch_server_passwords
 
@@ -81,10 +82,10 @@ class tasks(commands.Cog):
             backup_folder, f"backup_{datetime.now().strftime(date_format)}.json"
         )
         backup_data = {
-            "players": data_manager.get_all_player_entries(
-                archive=archive_type.INCLUDE, with_id=False
+            "players": data_manager.Players.get_profiles(
+                archive=archive_type.INCLUDE, with_id=False, as_json=True
             ),
-            "mogis": data_manager.get_all_mogi_entries(with_id=False),
+            "mogis": data_manager.Mogis.get_all_mogis(with_id=False, as_json=True),
         }
 
         with open(backup_filename, "w") as backup_file:

--- a/models/GuildModel.py
+++ b/models/GuildModel.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass, field
 from bson.objectid import ObjectId
 from bson.int64 import Int64
 
-from utils.data._database import db_guilds
-
 
 @dataclass
 class Guild:
@@ -28,15 +26,9 @@ class Guild:
     _creation_date: int | None = None
 
     # Getters and Setters
-    def update_attribute(self, attr_name: str, value):
-        setattr(self, f"_{attr_name}", value)
-        db_guilds.update_one(
-            {"_id": self._id},
-            {"$set": {attr_name: value}},
-        )
 
     """ def refresh(self):
-        data = db_guilds.find_one({"_id": self._id})
+        data = find_one({"_id": self._id})
         self.__dict__.update(Guild.from_json(data).__dict__) """
 
     # name

--- a/models/MogiModel.py
+++ b/models/MogiModel.py
@@ -2,11 +2,11 @@ import time, math
 from dataclasses import dataclass, field
 from bson import ObjectId
 
+from utils.data.data_manager import data_manager
 from .PlayerModel import PlayerProfile
 from .VoteModel import Vote
 from .RoomModel import Room
 
-from utils.data._database import db_mogis
 from utils.maths.teams_algorithm import (
     teams_alg_distribute_by_order_kevnkkm,
     teams_alg_random,
@@ -178,16 +178,14 @@ class Mogi:
         """
         Save the mogi to the database.
         """
-        db_mogis.insert_one(
-            {
-                "started_at": self.started_at,
-                "finished_at": self.finished_at,
-                "player_ids": [player.discord_id for player in self.players],
-                "format": self.format if not self.is_mini else 0,
-                "subs": len(self.subs),
-                "results": self.mmr_results_by_group,
-                "disconnections": self.disconnections,
-            }
+        data_manager.Mogis.add_mogi_history(
+            started_at=self.started_at,
+            finished_at=self.finished_at,
+            player_ids=[player.discord_id for player in self.players],
+            format=self.format if not self.is_mini else 0,
+            subs=len(self.subs),
+            results=self.mmr_results_by_group,
+            disconnections=self.disconnections,
         )
 
     def finish(self) -> None:

--- a/utils/data/__init__.py
+++ b/utils/data/__init__.py
@@ -1,5 +1,5 @@
 # from ._database import client, db_mogis, db_players, db_mogis
-from .data_manager import data_manager, archive_type
+from .data_manager import data_manager
 from .mogi_manager import mogi_manager
 from .roombrowser import get_room_info, ServerType
 from .state import state_manager
@@ -12,7 +12,6 @@ from .table_reader_api import (
 
 __all__ = [
     "data_manager",
-    "archive_type",
     "mogi_manager",
     "get_room_info",
     "ServerType",

--- a/utils/data/__init__.py
+++ b/utils/data/__init__.py
@@ -1,4 +1,4 @@
-# from ._database import client, db_mogis, db_players, db_archived, db_mogis
+# from ._database import client, db_mogis, db_players, db_mogis
 from .data_manager import data_manager, archive_type
 from .mogi_manager import mogi_manager
 from .roombrowser import get_room_info, ServerType

--- a/utils/data/_database.py
+++ b/utils/data/_database.py
@@ -1,9 +1,5 @@
 """
 This module is responsible for connecting to the MongoDB database.
-#### Exports:
-    db_players: Collection object
-    db_archived: Collection object
-    db_mogis: Collection object
 """
 
 import atexit
@@ -19,7 +15,7 @@ logger = setup_logger(__name__)
 client = MongoClient(MONGO_URI)
 db = client.get_database(LOUNGE_DB)
 db_players = db.get_collection("players")
-db_archived = db.get_collection("archived")
+db_guilds = db.get_collection("guilds")
 db_mogis = db.get_collection("mogis")
 db_aliases = db.get_collection("aliases")
 

--- a/utils/data/data_manager.py
+++ b/utils/data/data_manager.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from models.PlayerModel import PlayerProfile
 from models.MogiModel import MogiHistoryData
 
-from utils.data._database import client, db_players, db_mogis, db_aliases
+from utils.data._database import client, db_players, db_mogis, db_guilds, db_aliases
 
 from config import SEASON
 

--- a/utils/data/data_manager.py
+++ b/utils/data/data_manager.py
@@ -12,6 +12,7 @@ class DataManager:
         find = staticmethod(players.find_player)
         create = staticmethod(players.create_new_player)
         get_profiles = staticmethod(players.get_profiles)
+        count = staticmethod(players.count)
         set_attribute = staticmethod(players.set_attribute)
         append_history = staticmethod(players.append_history)
         count_format_played = staticmethod(players.count_format_played)

--- a/utils/data/data_manager.py
+++ b/utils/data/data_manager.py
@@ -10,7 +10,7 @@ from utils.database import mogis
 class DataManager:
     class Players:
         find = staticmethod(players.find_player)
-        create = staticmethod(players.create_new_player)
+        create_new_player = staticmethod(players.create_new_player)
         get_profiles = staticmethod(players.get_profiles)
         count = staticmethod(players.count)
         set_attribute = staticmethod(players.set_attribute)

--- a/utils/data/data_manager.py
+++ b/utils/data/data_manager.py
@@ -1,292 +1,42 @@
-from pymongo import UpdateOne
-from bson.int64 import Int64
-
-from enum import Enum
-
 from dataclasses import dataclass
-from models.PlayerModel import PlayerProfile
-from models.MogiModel import MogiHistoryData
 
-from utils.data._database import client, db_players, db_mogis, db_guilds, db_aliases
-
-from config import SEASON
-
-
-class archive_type(Enum):
-    NO = {"inactive": {"$ne": True}}
-    INCLUDE = {}
-    ONLY = {"inactive": True}
-
-
-class sort_type(Enum):
-    MMR = "MMR"
-    WINS = "Wins"
-    LOSSES = "Losses"
-    WINRATE = "Winrate %"
+from utils.database import players
+from utils.database import aliases
+from utils.database import leaderboard
+from utils.database import mogis
 
 
 @dataclass
 class DataManager:
-    def __init__(self):
-        pass
+    class Players:
+        find = staticmethod(players.find_player)
+        create = staticmethod(players.create_new_player)
+        get_profiles = staticmethod(players.get_profiles)
+        set_attribute = staticmethod(players.set_attribute)
+        append_history = staticmethod(players.append_history)
+        count_format_played = staticmethod(players.count_format_played)
+        delete = staticmethod(players.delete_player)
 
-    def find_player(
-        self,
-        query: int | Int64 | str,
-        archive: archive_type = archive_type.NO,
-        season: int = SEASON,
-    ) -> PlayerProfile | None:
-        query_criteria = {
-            "$and": [
-                {
-                    "$or": [
-                        {"name": (query.lower() if isinstance(query, str) else query)},
-                        {
-                            "discord_id": (
-                                Int64(query)
-                                if isinstance(query, Int64 | int)
-                                else (
-                                    Int64(query.strip("<@!>"))
-                                    if query.strip("<@!>").isdigit()
-                                    else None
-                                )
-                            )
-                        },
-                    ]
-                },
-                archive.value,
-            ]
-        }
+    class Aliases:
+        set_player_alias = staticmethod(aliases.set_player_alias)
+        get_all_aliases = staticmethod(aliases.get_all_aliases)
 
-        target_collection = client.get_database(
-            f"season-{season}-lounge"
-        ).get_collection("players")
+    class Leaderboard:
+        get_leaderboard = staticmethod(leaderboard.get_leaderboard)
 
-        potential_player = next(
-            target_collection.aggregate([{"$match": query_criteria}, {"$limit": 1}]),
-            None,
-        )
+    class Mogis:
+        get_all_mogis = staticmethod(mogis.get_all_mogis)
+        add_mogi_history = staticmethod(mogis.add_mogi_history)
+        apply_result_mmr = staticmethod(mogis.apply_result_mmr)
+        bulk_add_mmr = staticmethod(mogis.bulk_add_mmr)
 
-        return PlayerProfile(**potential_player) if potential_player else None
-
-    def get_all_player_profiles(
-        self,
-        archive: archive_type = archive_type.NO,
-        with_id: bool = False,
-    ) -> list[PlayerProfile] | list[dict] | None:
-        return [
-            PlayerProfile.from_json(player)
-            for player in list(
-                db_players.find(archive.value, {"_id": 0} if not with_id else {})
-            )
-        ]
-
-    def get_all_player_entries(
-        self,
-        archive: archive_type = archive_type.NO,
-        with_id: bool = False,
-    ) -> list[dict] | None:
-        return list(db_players.find(archive.value, {"_id": 0} if not with_id else {}))
-
-    def get_player_alias(self, username: str) -> str:
-        doc = db_aliases.find_one({"name": username})
-        if doc:
-            return doc["alias"]
-
-    def set_player_alias(self, username: str, new_alias: str) -> None:
-        if not db_players.find_one({"name": username}):
-            return
-        db_aliases.update_one(
-            {"name": username}, {"$set": {"alias": new_alias}}, upsert=True
-        )
-
-    def get_all_aliases(self) -> dict[str, str]:
-        entries = list(db_aliases.find({}))
-        return {entry["name"]: entry["alias"] for entry in entries}
-
-    def create_new_player(self, username: str, discord_id: int, join_time: int) -> None:
-        db_players.insert_one(
-            {
-                "name": username,
-                "discord_id": Int64(discord_id),
-                "mmr": 2000,
-                "history": [],
-                "joined": join_time,
-            },
-        )
-
-    def get_leaderboard(
-        self, page_index: int, sort: sort_type = sort_type.MMR
-    ) -> list[dict] | None:
-        total_player_count = db_players.count_documents({})
-
-        page_index = page_index if page_index > 0 else 1
-        max_pages = -(-total_player_count // 10)
-
-        page_index = page_index if page_index <= max_pages else max_pages
-
-        skip_count = 10 * (page_index - 1)
-        skip_count = (
-            skip_count if skip_count < total_player_count else total_player_count - 10
-        )
-        skip_count = skip_count if skip_count >= 0 else 0
-
-        pipeline = []
-
-        # Add match stage to filter out inactive players
-        pipeline.append(
-            {
-                "$match": {
-                    "inactive": {"$ne": True},
-                    "history": {"$exists": True, "$not": {"$size": 0}},
-                }
-            }
-        )
-
-        # Add fields for Wins and Losses directly to the query results
-        pipeline.append(
-            {
-                "$project": {
-                    "_id": 0,
-                    "name": 1,
-                    "mmr": 1,
-                    "history": 1,
-                    "Wins": {
-                        "$size": {
-                            "$filter": {
-                                "input": "$history",
-                                "as": "delta",
-                                "cond": {"$gte": ["$$delta", 0]},
-                            }
-                        }
-                    },
-                    "Losses": {
-                        "$size": {
-                            "$filter": {
-                                "input": "$history",
-                                "as": "delta",
-                                "cond": {"$lt": ["$$delta", 0]},
-                            }
-                        }
-                    },
-                }
-            }
-        )
-
-        # Calculate winrate
-        pipeline.append(
-            {
-                "$addFields": {
-                    "Winrate %": {
-                        "$cond": [
-                            {"$eq": [{"$add": ["$Wins", "$Losses"]}, 0]},
-                            0,
-                            {
-                                "$multiply": [
-                                    {
-                                        "$divide": [
-                                            "$Wins",
-                                            {"$add": ["$Wins", "$Losses"]},
-                                        ]
-                                    },
-                                    100,
-                                ]
-                            },
-                        ]
-                    }
-                }
-            }
-        )
-
-        sort_field = "mmr" if sort.value == "MMR" else sort.value
-        pipeline.append({"$sort": {sort_field: -1}})
-
-        pipeline.append({"$skip": skip_count})
-        pipeline.append({"$limit": 10})
-
-        return list(db_players.aggregate(pipeline))
-
-    def delete_player(self, query: int | Int64 | str):
-        pass
-
-    def get_all_mogis(self, with_id: bool = False) -> list[MogiHistoryData]:
-        return [
-            MogiHistoryData.from_dict(mogi)
-            for mogi in list(db_mogis.find({}, {"_id": 0} if not with_id else {}))
-        ]
-
-    def get_all_mogi_entries(self, with_id: bool = False) -> list[dict]:
-        return list(db_mogis.find({}, {"_id": 0} if not with_id else {}))
-
-    def add_mogi_history(
-        self,
-        started_at: int,
-        finished_at: int,
-        player_ids: list[int],
-        format: int,
-        subs: int,
-        results: list[int],
-        disconnections: int,
-    ) -> None:
-        db_mogis.insert_one(
-            {
-                "started_at": started_at,
-                "finished_at": finished_at,
-                "player_ids": player_ids,
-                "format": format,
-                "subs": subs,
-                "results": results,
-                "disconnections": disconnections,
-            }
-        )
-
-    def apply_result_mmr(self, usernames: list[str], deltas: list[int]) -> None:
-        """
-        ### Apply MMR results to players
-        Note: Subs need to be removed prior from this list, the function does not check for this.
-        """
-        db_players.bulk_write(
-            [
-                UpdateOne(
-                    {"name": entry["name"]},
-                    {
-                        "$set": {
-                            "mmr": {"$max": [1, {"$add": ["$mmr", entry["delta"]]}]}
-                        },
-                        "$push": {"history": entry["delta"]},
-                    },
-                    upsert=False,
-                )
-                for entry in (
-                    {"name": usernames[i], "delta": deltas[i]}
-                    for i in range(len(usernames))
-                )
-            ]
-        )
-
-    def bulk_add_mmr(self, player_usernames: list[str], amount: int) -> None:
-        """
-        ### Add a certain `amount` of MMR to every player (by username) provided.
-        `amount` may be negative\n
-        It's ensured each player's MMR is still 1 or more total.
-        """
-        db_players.bulk_write(
-            [
-                UpdateOne(
-                    {"name": username},
-                    [
-                        {
-                            "$set": {
-                                "mmr": {"$max": [1, {"$add": ["$mmr", amount]}]},
-                            },
-                            "$push": {"history": amount},
-                        }
-                    ],
-                    upsert=False,
-                )
-                for username in player_usernames
-            ]
-        )
+    class Guilds:
+        get_all_guilds = None
+        create = None
+        delete = None
+        add_member = None
+        remove_member = None
+        set_attribute = None
 
 
 data_manager = DataManager()

--- a/utils/data/table_reader_api.py
+++ b/utils/data/table_reader_api.py
@@ -80,13 +80,15 @@ def pattern_match_lounge_names(
     # Check aliases and override if higher confidence
     for i, name in enumerate(players):
         attempt: tuple[str, int] | None = process.extractOne(
-            name, list((data_manager.get_all_aliases()).values())
+            name, list((data_manager.Aliases.get_all_aliases()).values())
         )
         if attempt:
             potential_alias_match, certainty = attempt
             if potential_alias_match and certainty > 70:
                 # Find the key for this alias value
-                for alias_key, alias_val in (data_manager.get_all_aliases()).items():
+                for alias_key, alias_val in (
+                    data_manager.Aliases.get_all_aliases()
+                ).items():
                     if alias_val == potential_alias_match:
                         actual_names[i] = alias_key
                         print(f"Alias match: {name} → {alias_key} ({certainty})")

--- a/utils/database/aliases.py
+++ b/utils/database/aliases.py
@@ -1,0 +1,17 @@
+from utils.data._database import db_aliases
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.PlayerModel import PlayerProfile
+
+
+def set_player_alias(player: PlayerProfile, new_alias: str) -> None:
+    db_aliases.update_one(
+        {"name": player.name}, {"$set": {"alias": new_alias}}, upsert=True
+    )
+
+
+def get_all_aliases() -> dict[str, str]:
+    entries = list(db_aliases.find({}))
+    return {entry["name"]: entry["alias"] for entry in entries}

--- a/utils/database/leaderboard.py
+++ b/utils/database/leaderboard.py
@@ -1,0 +1,98 @@
+from utils.data._database import db_players
+from utils.database.types import archive_type, sort_type
+
+
+def get_leaderboard(
+    page_index: int,
+    sort: sort_type = sort_type.MMR,
+    archive: archive_type = archive_type.NO,
+) -> list[dict] | None:
+    total_player_count = db_players.count_documents({})
+
+    page_index = page_index if page_index > 0 else 1
+    max_pages = -(-total_player_count // 10)
+
+    page_index = page_index if page_index <= max_pages else max_pages
+
+    skip_count = 10 * (page_index - 1)
+    skip_count = (
+        skip_count if skip_count < total_player_count else total_player_count - 10
+    )
+    skip_count = skip_count if skip_count >= 0 else 0
+
+    pipeline = []
+
+    # Add match stage to filter players
+    filter = {
+        "inactive": {"$ne": True},
+        "history": {"$exists": True, "$not": {"$size": 0}},
+    }
+    if archive == archive_type.NO:
+        filter["archived"] = {"$ne": True}
+    if archive == archive_type.ONLY:
+        filter["archived"] = True
+
+    pipeline.append({"$match": filter})
+
+    # Add fields for Wins and Losses directly to the query results
+    pipeline.append(
+        {
+            "$project": {
+                "_id": 0,
+                "name": 1,
+                "mmr": 1,
+                "history": 1,
+                "Wins": {
+                    "$size": {
+                        "$filter": {
+                            "input": "$history",
+                            "as": "delta",
+                            "cond": {"$gte": ["$$delta", 0]},
+                        }
+                    }
+                },
+                "Losses": {
+                    "$size": {
+                        "$filter": {
+                            "input": "$history",
+                            "as": "delta",
+                            "cond": {"$lt": ["$$delta", 0]},
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    # Calculate winrate
+    pipeline.append(
+        {
+            "$addFields": {
+                "Winrate %": {
+                    "$cond": [
+                        {"$eq": [{"$add": ["$Wins", "$Losses"]}, 0]},
+                        0,
+                        {
+                            "$multiply": [
+                                {
+                                    "$divide": [
+                                        "$Wins",
+                                        {"$add": ["$Wins", "$Losses"]},
+                                    ]
+                                },
+                                100,
+                            ]
+                        },
+                    ]
+                }
+            }
+        }
+    )
+
+    sort_field = "mmr" if sort.value == "MMR" else sort.value
+    pipeline.append({"$sort": {sort_field: -1}})
+
+    pipeline.append({"$skip": skip_count})
+    pipeline.append({"$limit": 10})
+
+    return list(db_players.aggregate(pipeline))

--- a/utils/database/mogis.py
+++ b/utils/database/mogis.py
@@ -1,0 +1,89 @@
+from pymongo import UpdateOne
+from utils.data._database import db_players, db_mogis
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.PlayerModel import PlayerProfile
+    from models.MogiModel import MogiHistoryData
+
+
+def get_all_mogis(
+    with_id: bool = False, as_json: bool = False
+) -> list[MogiHistoryData] | list[dict]:
+    data: list[dict] = list(
+        db_mogis.find({}, {"_id": 0} if not (with_id or not as_json) else {})
+    )
+    if as_json:
+        return data
+    return [MogiHistoryData.from_dict(mogi) for mogi in data]
+
+
+def add_mogi_history(
+    started_at: int,
+    finished_at: int,
+    player_ids: list[int],
+    format: int,
+    subs: int,
+    results: list[int],
+    disconnections: int,
+) -> None:
+    db_mogis.insert_one(
+        {
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "player_ids": player_ids,
+            "format": format,
+            "subs": subs,
+            "results": results,
+            "disconnections": disconnections,
+        }
+    )
+
+
+def apply_result_mmr(usernames: list[str], deltas: list[int]) -> None:
+    """
+    ### Apply MMR results to players
+    Note: Subs need to be removed prior from this list, the function does not check for this.
+    """
+    db_players.bulk_write(
+        [
+            UpdateOne(
+                {"name": entry["name"]},
+                {
+                    "$set": {"mmr": {"$max": [1, {"$add": ["$mmr", entry["delta"]]}]}},
+                    "$push": {"history": entry["delta"]},
+                },
+                upsert=False,
+            )
+            for entry in (
+                {"name": usernames[i], "delta": deltas[i]}
+                for i in range(len(usernames))
+            )
+        ]
+    )
+
+
+def bulk_add_mmr(player_usernames: list[str], amount: int) -> None:
+    """
+    ### Add a certain `amount` of MMR to every player (by username) provided.
+    `amount` may be negative\n
+    It's ensured each player's MMR is still 1 or more total.
+    """
+    db_players.bulk_write(
+        [
+            UpdateOne(
+                {"name": username},
+                [
+                    {
+                        "$set": {
+                            "mmr": {"$max": [1, {"$add": ["$mmr", amount]}]},
+                        },
+                        "$push": {"history": amount},
+                    }
+                ],
+                upsert=False,
+            )
+            for username in player_usernames
+        ]
+    )

--- a/utils/database/players.py
+++ b/utils/database/players.py
@@ -17,6 +17,7 @@ def find_player(
         "$and": [
             {
                 "$or": [
+                    {"_id": query},
                     {"name": (query.lower() if isinstance(query, str) else query)},
                     {
                         "discord_id": (
@@ -67,6 +68,7 @@ def create_new_player(username: str, discord_id: int) -> None:
             "discord_id": Int64(discord_id),
             "mmr": 2000,
             "history": [],
+            "formats": {str(i): 0 for i in range(7)},
             "joined": round(time()),
         },
     )
@@ -76,7 +78,7 @@ def set_attribute(player: PlayerProfile, attribute, value) -> None:
     setattr(player, attribute, value)
     db_players.update_one(
         {"_id": player._id},
-        {"$set": {attribute: value}},
+        {"$set" if value else "$unset": {attribute: value if value else ""}},
     )
 
 

--- a/utils/database/players.py
+++ b/utils/database/players.py
@@ -1,0 +1,96 @@
+from bson.int64 import Int64
+from time import time
+from utils.database.types import archive_type
+from utils.data._database import db_players
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.PlayerModel import PlayerProfile
+
+
+def find_player(
+    query: int | Int64 | str,
+    archive: archive_type = archive_type.NO,
+) -> PlayerProfile | None:
+    query_criteria = {
+        "$and": [
+            {
+                "$or": [
+                    {"name": (query.lower() if isinstance(query, str) else query)},
+                    {
+                        "discord_id": (
+                            Int64(query)
+                            if isinstance(query, Int64 | int)
+                            else (
+                                Int64(query.strip("<@!>"))
+                                if query.strip("<@!>").isdigit()
+                                else None
+                            )
+                        )
+                    },
+                ]
+            },
+            archive.value,
+        ]
+    }
+
+    potential_player = next(
+        db_players.aggregate([{"$match": query_criteria}, {"$limit": 1}]),
+        None,
+    )
+
+    return PlayerProfile(**potential_player) if potential_player else None
+
+
+def get_profiles(
+    archive: archive_type = archive_type.NO,
+    with_id: bool = False,
+    as_json: bool = False,
+) -> list[PlayerProfile] | list[dict] | None:
+    data: list[dict] = list(
+        db_players.find(archive.value, {"_id": 0} if not with_id else {})
+    )
+    if as_json:
+        return data
+    return [PlayerProfile.from_json(player) for player in data]
+
+
+def create_new_player(username: str, discord_id: int) -> None:
+    db_players.insert_one(
+        {
+            "name": username,
+            "discord_id": Int64(discord_id),
+            "mmr": 2000,
+            "history": [],
+            "joined": round(time()),
+        },
+    )
+
+
+def set_attribute(player: PlayerProfile, attribute, value) -> None:
+    setattr(player, attribute, value)
+    db_players.update_one(
+        {"_id": player._id},
+        {"$set": {attribute: value}},
+    )
+
+
+def append_history(player: PlayerProfile, score: int) -> None:
+    player.history.append(score)
+    db_players.update_one(
+        {"_id": player._id},
+        {"$push": {"history": score}},
+    )
+
+
+def count_format_played(player: PlayerProfile, value):
+    player._formats[value] += 1
+    db_players.update_one(
+        {"_id": player._id},
+        {"$inc": {f"formats.{value}": 1}},
+    )
+
+
+def delete_player(player: PlayerProfile):
+    db_players.delete_one({"_id": player._id})

--- a/utils/database/players.py
+++ b/utils/database/players.py
@@ -43,6 +43,10 @@ def find_player(
     return PlayerProfile(**potential_player) if potential_player else None
 
 
+def count() -> int:
+    return db_players.count_documents({})
+
+
 def get_profiles(
     archive: archive_type = archive_type.NO,
     with_id: bool = False,

--- a/utils/database/types.py
+++ b/utils/database/types.py
@@ -1,0 +1,15 @@
+import enum
+from typing import Enum
+
+
+class archive_type(Enum):
+    NO = {"inactive": {"$ne": True}}
+    INCLUDE = {}
+    ONLY = {"inactive": True}
+
+
+class sort_type(Enum):
+    MMR = "MMR"
+    WINS = "Wins"
+    LOSSES = "Losses"
+    WINRATE = "Winrate %"

--- a/utils/decorators/player.py
+++ b/utils/decorators/player.py
@@ -4,7 +4,8 @@ from bson.int64 import Int64
 from models.CustomMogiContext import MogiApplicationContext
 from utils.command_helpers.find_player import get_guild_member
 
-from utils.data import data_manager, archive_type, mogi_manager
+from utils.database.types import archive_type
+from utils.data import data_manager, mogi_manager
 
 
 def with_player(
@@ -34,7 +35,7 @@ def with_player(
             # if not provided, choose the command user
 
             # Fetch player record and assign discord user as well
-            ctx.player = data_manager.find_player(
+            ctx.player = data_manager.Players.find(
                 query=ctx.user.id, archive=archive_type.INCLUDE
             )
 
@@ -101,7 +102,7 @@ def other_player(
             target_query: str | int | Int64 = kwargs.get(query_varname, None)
 
             # Fetch player record and assign discord user as well
-            ctx.player = data_manager.find_player(
+            ctx.player = data_manager.Players.find(
                 query=target_query, archive=archive_type.INCLUDE
             )
 


### PR DESCRIPTION
This PR finally addresses some scalability concerns with the bot. 
Interactions with the database have been messy and inconsistent.
Now, *only* dedicated utilities in `utils/database/` may interact with the database. 

They each contain predefined methods that perform certain common operations like adding and modifying players.
The `DataManager` class has been rewritten to incorporate these utilities with subclasses for each area of data.

before:
```py
# cogs/profiles/register.py
db_players.insert_one(
  {
      "name": username,
      "discord_id": Int64(member.id),
      "mmr": 2000,
      "history": [],
      "joined": round(time.time()),
      "formats": {str(i): 0 for i in range(7)},
  },
)
```

This is very bad practice as it mixes up the user-facing code with business-logic.

after:
```py
# cogs/profiles/register.py
data_manager.Players.create_new_player(
   username=username, discord_id=member.id
)
```

This PR will be merged soon, after I finish some coordination with the soon to be implemented guilds.

            